### PR TITLE
Add use cases from notifications protocol document

### DIFF
--- a/notifications-ucr.html
+++ b/notifications-ucr.html
@@ -452,7 +452,7 @@ border-right-color: #eee;
                 <div datatype="rdf:HTML" property="skos:definition">
                   <p>
                     Sometimes a client doesn't need to be alerted for every change. If a client only needs
-                    infrequent updates, for example, every 5 minutes, it should be possible to avoid floods
+                    infrequent updates (for example, every 5 minutes), it should be possible to avoid floods
                     of data that might otherwise place a higher burden on the client application. Ideally,
                     a client should be able to define what that aggregation window would be: for some clients,
                     10 seconds might be appropriate; for others, several minutes might be more appropriate.
@@ -528,12 +528,12 @@ border-right-color: #eee;
                 <h3 property="skos:prefLabel">Capability Discovery</h3>
                 <div datatype="rdf:HTML" property="skos:definition">
                   <p>
-                    A given Solid Notification server may support certain technologies (e.g. WebSockets and LDN)
-                    but not others (e.g. EventSource and WebSub). Likewise, a client may not support the same set
+                    A given Solid Notification server may support certain technologies (e.g., WebSockets and LDN)
+                    but not others (e.g., EventSource and WebSub). Likewise, a client may not support the same set
                     of technologies that are implemented by a server. As such, there needs to be a mechanism for
                     clients and servers to agree on a mutually supported subscription type. In addition to simply
                     determining the set of protocols that work for client and server, there may be particular
-                    features (e.g. notification aggregation, notification filtering) that are required by the client.
+                    features (e.g., notification aggregation, notification filtering) that are required by the client.
                     This could be used to further filter the protocol selection.
                   </p>
                   <dl id="requirements-filtered-notifications" rel="rdfs:seeAlso">

--- a/notifications-ucr.html
+++ b/notifications-ucr.html
@@ -442,6 +442,7 @@ border-right-color: #eee;
                     <dd><a href="#functional-requirement-create-events">Create Events</a></dd>
                     <dd><a href="#functional-requirement-update-events">Update Events</a></dd>
                     <dd><a href="#functional-requirement-delete-events">Delete Events</a></dd>
+                    <dd><a href="#functional-requirement-access-control">Authorization</a></dd>
                   </dl>
                 </div>
               </section>
@@ -462,6 +463,7 @@ border-right-color: #eee;
                     <dd><a href="#functional-requirement-update-events">Update Events</a></dd>
                     <dd><a href="#functional-requirement-delete-events">Delete Events</a></dd>
                     <dd><a href="#functional-requirement-event-filtering">Event Filtering</a></dd>
+                    <dd><a href="#functional-requirement-access-control">Authorization</a></dd>
                   </dl>
                 </div>
               </section>
@@ -480,6 +482,44 @@ border-right-color: #eee;
                     <dd><a href="#functional-requirement-update-events">Update Events</a></dd>
                     <dd><a href="#functional-requirement-delete-events">Delete Events</a></dd>
                     <dd><a href="#functional-requirement-event-filtering">Event Filtering</a></dd>
+                    <dd><a href="#functional-requirement-access-control">Authorization</a></dd>
+                  </dl>
+                </div>
+              </section>
+
+              <section id="use-case-time-bound-subscriptions" inlist="" rel="skos:member" resource="#use-case-time-bound-subscriptions" typeof="skos:Concept">
+                <h3 property="skos:prefLabel">Time-bound Subscriptions</h3>
+                <div datatype="rdf:HTML" property="skos:definition">
+                  <p>
+                    Occasionally, a client only needs a subscription to be in effect for a limited
+                    period of time. While a client may easily close a WebSocket itself, subscriptions
+                    for other, more asynchronous forms of notifications, such as LDN alerts or WebHook
+                    operations, may be more difficult to terminate.
+                  </p>
+                  <dl id="requirements-time-bound-subscriptions" rel="rdfs:seeAlso">
+                    <dt>Requirements</dt>
+                    <dd><a href="#functional-requirement-create-events">Create Events</a></dd>
+                    <dd><a href="#functional-requirement-update-events">Update Events</a></dd>
+                    <dd><a href="#functional-requirement-delete-events">Delete Events</a></dd>
+                    <dd><a href="#functional-requirement-access-control">Authorization</a></dd>
+                  </dl>
+                </div>
+              </section>
+
+              <section id="use-case-lost-updates" inlist="" rel="skos:member" resource="#use-case-lost-updates" typeof="skos:Concept">
+                <h3 property="skos:prefLabel">Lost Update Notifications</h3>
+                <div datatype="rdf:HTML" property="skos:definition">
+                  <p>
+                    For WebSockets and subscriptions that rely on an active, live connection to
+                    a notification server, the subscription channel needs to make sure that clients
+                    do not miss notifications in the event of a dropped connection.
+                  </p>
+                  <dl id="requirements-time-bound-subscriptions" rel="rdfs:seeAlso">
+                    <dt>Requirements</dt>
+                    <dd><a href="#functional-requirement-create-events">Create Events</a></dd>
+                    <dd><a href="#functional-requirement-update-events">Update Events</a></dd>
+                    <dd><a href="#functional-requirement-delete-events">Delete Events</a></dd>
+                    <dd><a href="#functional-requirement-access-control">Authorization</a></dd>
                   </dl>
                 </div>
               </section>
@@ -520,7 +560,7 @@ border-right-color: #eee;
                 <thead>
                   <tr>
                     <th rowspan="2">Use Case</th>
-                    <th colspan="5">Functional Requirements</th>
+                    <th colspan="6">Functional Requirements</th>
                     <th colspan="1">Non-Functional Requirements</th>
                   </tr>
                   <tr>
@@ -528,7 +568,8 @@ border-right-color: #eee;
                     <td><a href="#functional-requirement-update-events">F2</a></td>
                     <td><a href="#functional-requirement-delete-events">F3</a></td>
                     <td><a href="#functional-requirement-event-filtering">F4</a></td>
-                    <td><a href="#functional-requirement-discovery">F5</a></td>
+                    <td><a href="#functional-requirement-access-control">F5</a></td>
+                    <td><a href="#functional-requirement-discovery">F6</a></td>
                     <td><a href="#non-functional-requirement-baz">NF1</a></td>
                   </tr>
                 </thead>
@@ -539,11 +580,13 @@ border-right-color: #eee;
                     <td>✔</td>
                     <td>✔</td>
                     <td>⌙</td>
+                    <td>✔</td>
                     <td>⌙</td>
                     <td>⌙</td>
                   </tr>
                   <tr>
                     <td><a href="#use-case-change-frequency">Frequency of Notifications</a></td>
+                    <td>✔</td>
                     <td>✔</td>
                     <td>✔</td>
                     <td>✔</td>
@@ -557,11 +600,33 @@ border-right-color: #eee;
                     <td>✔</td>
                     <td>✔</td>
                     <td>✔</td>
+                    <td>✔</td>
+                    <td>⌙</td>
+                    <td>⌙</td>
+                  </tr>
+                  <tr>
+                    <td><a href="#use-case-time-bound-subscriptions">Time-Bound Subscriptions</a></td>
+                    <td>✔</td>
+                    <td>✔</td>
+                    <td>✔</td>
+                    <td>⌙</td>
+                    <td>✔</td>
+                    <td>⌙</td>
+                    <td>⌙</td>
+                  </tr>
+                  <tr>
+                    <td><a href="#use-case-lost-updates">Lost Update Notifications</a></td>
+                    <td>✔</td>
+                    <td>✔</td>
+                    <td>✔</td>
+                    <td>⌙</td>
+                    <td>✔</td>
                     <td>⌙</td>
                     <td>⌙</td>
                   </tr>
                   <tr>
                     <td><a href="#use-case-capability-discovery">Capability Discovery</a></td>
+                    <td>⌙</td>
                     <td>⌙</td>
                     <td>⌙</td>
                     <td>⌙</td>
@@ -592,6 +657,7 @@ border-right-color: #eee;
                     <span resource="#functional-requirement-update-events"></span>
                     <span resource="#functional-requirement-delete-events"></span>
                     <span resource="#functional-requirement-event-filtering"></span>
+                    <span resource="#functional-requirement-access-control"></span>
                     <span resource="#functional-requirement-discovery"></span>
                   </span>
 
@@ -604,7 +670,9 @@ border-right-color: #eee;
                     <dd about="#functional-requirement-delete-events" property="skos:definition">A subscribed entity is alerted when an existing resource is deleted.</dd>
                     <dt about="#functional-requirement-event-filtering" property="skos:definition" typeof="skos:Concept">F4. <dfn id="functional-requirement-event-filtering">Event Filtering</dfn></dt>
                     <dd about="#functional-requirement-event-filtering" property="skos:definition">A subscribed entity can request a subset of all notifications.</dd>
-                    <dt about="#functional-requirement-discovery" property="skos:definition" typeof="skos:Concept">F5. <dfn id="functional-requirement-discovery">Capability Discovery</dfn></dt>
+                    <dt about="#functional-requirement-access-control" property="skos:definition" typeof="skos:Concept">F5. <dfn id="functional-requirement-access-control">Authorization</dfn></dt>
+                    <dd about="#functional-requirement-access-control" property="skos:definition">Authorization is enforced on all subscriptions.</dd>
+                    <dt about="#functional-requirement-discovery" property="skos:definition" typeof="skos:Concept">F6. <dfn id="functional-requirement-discovery">Capability Discovery</dfn></dt>
                     <dd about="#functional-requirement-discovery" property="skos:definition">A client is able to discover the notification capabilities of a Solid Storage.</dd>
                   </dl>
                 </div>

--- a/notifications-ucr.html
+++ b/notifications-ucr.html
@@ -484,6 +484,25 @@ border-right-color: #eee;
                 </div>
               </section>
 
+              <section id="use-case-capability-discovery" inlist="" rel="skos:member" resource="#use-case-capability-discovery" typeof="skos:Concept">
+                <h3 property="skos:prefLabel">Capability Discovery</h3>
+                <div datatype="rdf:HTML" property="skos:definition">
+                  <p>
+                    A given Solid Notification server may support certain technologies (e.g. WebSockets and LDN)
+                    but not others (e.g. EventSource and WebSub). Likewise, a client may not support the same set
+                    of technologies that are implemented by a server. As such, there needs to be a mechanism for
+                    clients and servers to agree on a mutually supported subscription type. In addition to simply
+                    determining the set of protocols that work for client and server, there may be particular
+                    features (e.g. notification aggregation, notification filtering) that are required by the client.
+                    This could be used to further filter the protocol selection.
+                  </p>
+                  <dl id="requirements-filtered-notifications" rel="rdfs:seeAlso">
+                    <dt>Requirements</dt>
+                    <dd><a href="#functional-requirement-discovery">Capability Discovery</a></dd>
+                  </dl>
+                </div>
+              </section>
+
             </div>
           </section>
 
@@ -501,7 +520,7 @@ border-right-color: #eee;
                 <thead>
                   <tr>
                     <th rowspan="2">Use Case</th>
-                    <th colspan="4">Functional Requirements</th>
+                    <th colspan="5">Functional Requirements</th>
                     <th colspan="1">Non-Functional Requirements</th>
                   </tr>
                   <tr>
@@ -509,6 +528,7 @@ border-right-color: #eee;
                     <td><a href="#functional-requirement-update-events">F2</a></td>
                     <td><a href="#functional-requirement-delete-events">F3</a></td>
                     <td><a href="#functional-requirement-event-filtering">F4</a></td>
+                    <td><a href="#functional-requirement-discovery">F5</a></td>
                     <td><a href="#non-functional-requirement-baz">NF1</a></td>
                   </tr>
                 </thead>
@@ -520,6 +540,7 @@ border-right-color: #eee;
                     <td>✔</td>
                     <td>⌙</td>
                     <td>⌙</td>
+                    <td>⌙</td>
                   </tr>
                   <tr>
                     <td><a href="#use-case-change-frequency">Frequency of Notifications</a></td>
@@ -528,8 +549,8 @@ border-right-color: #eee;
                     <td>✔</td>
                     <td>✔</td>
                     <td>⌙</td>
+                    <td>⌙</td>
                   </tr>
-
                   <tr>
                     <td><a href="#use-case-filtered-notifications">Filtered Notifications</a></td>
                     <td>✔</td>
@@ -537,8 +558,17 @@ border-right-color: #eee;
                     <td>✔</td>
                     <td>✔</td>
                     <td>⌙</td>
+                    <td>⌙</td>
                   </tr>
-
+                  <tr>
+                    <td><a href="#use-case-capability-discovery">Capability Discovery</a></td>
+                    <td>⌙</td>
+                    <td>⌙</td>
+                    <td>⌙</td>
+                    <td>⌙</td>
+                    <td>✔</td>
+                    <td>⌙</td>
+                  </tr>
                 </tbody>
                 <tfoot>
                   <tr>
@@ -562,6 +592,7 @@ border-right-color: #eee;
                     <span resource="#functional-requirement-update-events"></span>
                     <span resource="#functional-requirement-delete-events"></span>
                     <span resource="#functional-requirement-event-filtering"></span>
+                    <span resource="#functional-requirement-discovery"></span>
                   </span>
 
                   <dl>
@@ -573,6 +604,8 @@ border-right-color: #eee;
                     <dd about="#functional-requirement-delete-events" property="skos:definition">A subscribed entity is alerted when an existing resource is deleted.</dd>
                     <dt about="#functional-requirement-event-filtering" property="skos:definition" typeof="skos:Concept">F4. <dfn id="functional-requirement-event-filtering">Event Filtering</dfn></dt>
                     <dd about="#functional-requirement-event-filtering" property="skos:definition">A subscribed entity can request a subset of all notifications.</dd>
+                    <dt about="#functional-requirement-discovery" property="skos:definition" typeof="skos:Concept">F5. <dfn id="functional-requirement-discovery">Capability Discovery</dfn></dt>
+                    <dd about="#functional-requirement-discovery" property="skos:definition">A client is able to discover the notification capabilities of a Solid Storage.</dd>
                   </dl>
                 </div>
               </section>

--- a/notifications-ucr.html
+++ b/notifications-ucr.html
@@ -250,7 +250,7 @@ border-right-color: #eee;
 
         <dl id="document-modified">
           <dt>Modified</dt>
-          <dd><time content="2021-10-27T00:00:00Z" datatype="xsd:dateTime" datetime="2021-10-27T00:00:00Z" property="schema:dateModified">2021-10-27</time></dd>
+          <dd><time content="2022-01-20T00:00:00Z" datatype="xsd:dateTime" datetime="2022-01-22T00:00:00Z" property="schema:dateModified">2022-01-20</time></dd>
         </dl>
 
         <dl id="document-repository">
@@ -439,12 +439,51 @@ border-right-color: #eee;
 
                   <dl id="requirements-immediate-notification-data-changes" rel="rdfs:seeAlso">
                     <dt>Requirements</dt>
-                    <dd><a href="#functional-requirement-foo">Foo</a></dd>
-                    <dd><a href="#functional-requirement-bar">Bar</a></dd>
-                    <dd><a href="#functional-requirement-baz">Baz</a></dd>
+                    <dd><a href="#functional-requirement-create-events">Create Events</a></dd>
+                    <dd><a href="#functional-requirement-update-events">Update Events</a></dd>
+                    <dd><a href="#functional-requirement-delete-events">Delete Events</a></dd>
                   </dl>
                 </div>
               </section>
+
+              <section id="use-case-change-frequency" inlist="" rel="skos:member" resource="#use-case-change-frequency" typeof="skos:Concept">
+                <h3 property="skos:prefLabel">Frequency of Notifications</h3>
+                <div datatype="rdf:HTML" property="skos:definition">
+                  <p>
+                    Sometimes a client doesn't need to be alerted for every change. If a client only needs
+                    infrequent updates, for example, every 5 minutes, it should be possible to avoid floods
+                    of data that might otherwise place a higher burden on the client application. Ideally,
+                    a client should be able to define what that aggregation window would be: for some clients,
+                    10 seconds might be appropriate; for others, several minutes might be more appropriate.
+                  </p>
+                  <dl id="requirements-change-frequency" rel="rdfs:seeAlso">
+                    <dt>Requirements</dt>
+                    <dd><a href="#functional-requirement-create-events">Create Events</a></dd>
+                    <dd><a href="#functional-requirement-update-events">Update Events</a></dd>
+                    <dd><a href="#functional-requirement-delete-events">Delete Events</a></dd>
+                    <dd><a href="#functional-requirement-event-filtering">Event Filtering</a></dd>
+                  </dl>
+                </div>
+              </section>
+
+              <section id="use-case-filtered-notifications" inlist="" rel="skos:member" resource="#use-case-filtered-notifications" typeof="skos:Concept">
+                <h3 property="skos:prefLabel">Filtered Notifications</h3>
+                <div datatype="rdf:HTML" property="skos:definition">
+                  <p>
+                    Certain categories of notifications may be more or less interesting to clients.
+                    For example, a client may not care about UPDATE operations or may only care about
+                    notifications for resources of certain types.
+                  </p>
+                  <dl id="requirements-filtered-notifications" rel="rdfs:seeAlso">
+                    <dt>Requirements</dt>
+                    <dd><a href="#functional-requirement-create-events">Create Events</a></dd>
+                    <dd><a href="#functional-requirement-update-events">Update Events</a></dd>
+                    <dd><a href="#functional-requirement-delete-events">Delete Events</a></dd>
+                    <dd><a href="#functional-requirement-event-filtering">Event Filtering</a></dd>
+                  </dl>
+                </div>
+              </section>
+
             </div>
           </section>
 
@@ -462,13 +501,15 @@ border-right-color: #eee;
                 <thead>
                   <tr>
                     <th rowspan="2">Use Case</th>
-                    <th colspan="2">Functional Requirements</th>
+                    <th colspan="4">Functional Requirements</th>
                     <th colspan="1">Non-Functional Requirements</th>
                   </tr>
                   <tr>
-                    <td><a href="#functional-requirement-foo">F1</a></td>
-                    <td><a href="#functional-requirement-bar">F2</a></td>
-                    <td><a href="#non-functional-requirement-bar">NF1</a></td>
+                    <td><a href="#functional-requirement-create-events">F1</a></td>
+                    <td><a href="#functional-requirement-update-events">F2</a></td>
+                    <td><a href="#functional-requirement-delete-events">F3</a></td>
+                    <td><a href="#functional-requirement-event-filtering">F4</a></td>
+                    <td><a href="#non-functional-requirement-baz">NF1</a></td>
                   </tr>
                 </thead>
                 <tbody>
@@ -477,7 +518,27 @@ border-right-color: #eee;
                     <td>✔</td>
                     <td>✔</td>
                     <td>✔</td>
+                    <td>⌙</td>
+                    <td>⌙</td>
                   </tr>
+                  <tr>
+                    <td><a href="#use-case-change-frequency">Frequency of Notifications</a></td>
+                    <td>✔</td>
+                    <td>✔</td>
+                    <td>✔</td>
+                    <td>✔</td>
+                    <td>⌙</td>
+                  </tr>
+
+                  <tr>
+                    <td><a href="#use-case-filtered-notifications">Filtered Notifications</a></td>
+                    <td>✔</td>
+                    <td>✔</td>
+                    <td>✔</td>
+                    <td>✔</td>
+                    <td>⌙</td>
+                  </tr>
+
                 </tbody>
                 <tfoot>
                   <tr>
@@ -496,13 +557,22 @@ border-right-color: #eee;
                 <div datatype="rdf:HTML" property="schema:description">
                   <p><em>This section is non-normative.</em></p>
 
-                  <span rel="skos:member"><span resource="#functional-requirement-foo"></span><span resource="#functional-requirement-bar"></span></span>
+                  <span rel="skos:member">
+                    <span resource="#functional-requirement-create-events"></span>
+                    <span resource="#functional-requirement-update-events"></span>
+                    <span resource="#functional-requirement-delete-events"></span>
+                    <span resource="#functional-requirement-event-filtering"></span>
+                  </span>
 
                   <dl>
-                    <dt about="#functional-requirement-foo" property="skos:prefLabel" typeof="skos:Concept">F1. <dfn id="functional-requirement-foo">Foo</dfn></dt>
-                    <dd about="#functional-requirement-foo" property="skos:definition">Foo</dd>
-                    <dt about="#functional-requirement-bar" property="skos:prefLabel" typeof="skos:Concept">F2. <dfn id="functional-requirement-bar">Bar</dfn></dt>
-                    <dd about="#functional-requirement-bar" property="skos:definition">Bar</dd>
+                    <dt about="#functional-requirement-create-events" property="skos:prefLabel" typeof="skos:Concept">F1. <dfn id="functional-requirement-create-events">Create Events</dfn></dt>
+                    <dd about="#functional-requirement-create-events" property="skos:definition">A subscribed entity is alerted when a new resource is created.</dd>
+                    <dt about="#functional-requirement-update-events" property="skos:prefLabel" typeof="skos:Concept">F2. <dfn id="functional-requirement-update-events">Update Events</dfn></dt>
+                    <dd about="#functional-requirement-update-events" property="skos:definition">A subscribed entity is alerted when an existing resource is updated.</dd>
+                    <dt about="#functional-requirement-delete-events" property="skos:prefLabel" typeof="skos:Concept">F3. <dfn id="functional-requirement-delete-events">Delete Events</dfn></dt>
+                    <dd about="#functional-requirement-delete-events" property="skos:definition">A subscribed entity is alerted when an existing resource is deleted.</dd>
+                    <dt about="#functional-requirement-event-filtering" property="skos:definition" typeof="skos:Concept">F4. <dfn id="functional-requirement-event-filtering">Event Filtering</dfn></dt>
+                    <dd about="#functional-requirement-event-filtering" property="skos:definition">A subscribed entity can request a subset of all notifications.</dd>
                   </dl>
                 </div>
               </section>


### PR DESCRIPTION
This adds the use cases from the [Notifications Protocol document](https://solid.github.io/notifications/protocol#use-cases).

This will allow us to remove the use cases section from the protocol document and simply refer to the document here.